### PR TITLE
fix s3 bucket configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ resource "aws_route53_record" "301" {
 
 resource "aws_s3_bucket" "301" {
   bucket = "${substring(var.name, -2, -1) == "." ? substring(var.name, 0, length(var.name) - 1) : var.name}"
-  acl    = "public-read"
+  acl    = "${var.acl}"
 
   website {
     redirect_all_requests_to = "${var.target}"

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,8 @@ resource "aws_route53_record" "301" {
 }
 
 resource "aws_s3_bucket" "301" {
-  bucket = "${var.name}"
+  bucket = "${substring(var.name, -2, -1) == "." ? substring(var.name, 0, length(var.name) - 1) : var.name}"
+  acl    = "public-read"
 
   website {
     redirect_all_requests_to = "${var.target}"

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,6 @@
 variable "name" {}
 variable "zone_id" {}
 variable "target" {}
+variable "acl" {
+  default = "public-read"
+}


### PR DESCRIPTION
- strip trailing `.` when using `var.name` for the S3 bucket name (s3 buckets cannot end with `.`)
- add `acl` variable for setting S3 ACL, defaults to `public-read` (otherwise nobody can see it)